### PR TITLE
zero global variables

### DIFF
--- a/src/afglobal.c
+++ b/src/afglobal.c
@@ -38,5 +38,5 @@ int af_quiet             = 0;
 int af_silent_mode       = 0;
 int af_report_changes    = 0;
 int af_send_notify       = 0;
-sApp * af_app;
-int af_pause;
+sApp * af_app            = NULL;
+int af_pause             = 0;

--- a/src/areafix.c
+++ b/src/areafix.c
@@ -92,7 +92,7 @@
 #define FLAG_CMD_LINE 1
 #define FLAG_FROM_LOCAL_AKA 2
 
-unsigned char RetFix;
+unsigned char RetFix     = 0;
 static int rescanMode    = 0;
 static int foundToRescan = 0;
 static int rulesCount    = 0;


### PR DESCRIPTION
Fixes linker error building on MacOS X Tiger:
"ld: common symbols not allowed with MH_DYLIB output format with the -multi_module option"
